### PR TITLE
Dobra o volume quando texto contiver espaço

### DIFF
--- a/TCP/src/Translator.java
+++ b/TCP/src/Translator.java
@@ -2,20 +2,23 @@ public class Translator {
 
     public void translate(String text){
 
-        double volumePercent = 0.1D;
+        double MIN_VOL = 0.1D;
+        double MAX_VOL = 1.0D;
+        double volumePercent = MIN_VOL;
 
         for(int i=0; i<text.length(); i++){
             char c = text.charAt(i);
 
             switch (c){
-                case '+':
+                case ' ':
                     volumePercent = volumePercent * 2;
-                    break;
-                case '-':
-                    volumePercent = volumePercent / 2;
                     break;
             }
 
+        }
+
+        if (volumePercent > MAX_VOL){
+            volumePercent = MIN_VOL;
         }
 
         System.out.println(volumePercent);
@@ -28,8 +31,6 @@ public class Translator {
         int instrumento = 125;
 
         new MidiPlayer(notas, instrumento, volumePercent);
-
-
 
     }
 


### PR DESCRIPTION
R4/5: Se o texto submetido contiver a tecla de espaço, o software deve atualizar o volume para o dobro do atual. Caso não seja possível aumentar mais, o valor do volume deve voltar ao default.